### PR TITLE
Adapt the keyboard layout for the Rangen

### DIFF
--- a/src/components/kbmapping1.json
+++ b/src/components/kbmapping1.json
@@ -24,7 +24,7 @@
         "direction": null
     },
     " ": {
-        "button": 6,
+        "button": 7,
         "toggle": false,
         "axis": -1,
         "direction": null
@@ -42,13 +42,13 @@
         "toggle": null
     },
     "a": {
-        "axis": 0,
+        "axis": 2,
         "direction": "+",
         "button": -1,
         "toggle": null
     },
     "d": {
-        "axis": 0,
+        "axis": 2,
         "direction": "-",
         "button": -1,
         "toggle": null

--- a/src/components/kbmapping1.json
+++ b/src/components/kbmapping1.json
@@ -24,6 +24,12 @@
         "direction": null
     },
     " ": {
+        "button": 6,
+        "toggle": false,
+        "axis": -1,
+        "direction": null
+    },
+    "Shift": {
         "button": 7,
         "toggle": false,
         "axis": -1,


### PR DESCRIPTION
These modifications make it possible to remote control the Rangen from Foxglove using only a keyboard instead of a controller. It can replace any controller, as long as you select "Keyboard" as the "Data source" and enable it in the Joystick window.
![image](https://github.com/AlexLapy/foxglove-joystick/assets/22780933/7231e914-bf8c-452b-abb6-a6611fbf897c)

You simply need to hold the space bar, like a dead man switch, and then use the WASD keys to control the direction of the robot.

The only problem is that it only seems to work for maybe 4 or 5 seconds, then it stops working for a few seconds, and then it starts working again. Could this be an issue with the twist mux?

Also, I have only tested this in simulation for now, but I'm guessing it will work without any issue on the real robot.

